### PR TITLE
Meeza qr

### DIFF
--- a/lib/widgets/checkout/checkout_options.dart
+++ b/lib/widgets/checkout/checkout_options.dart
@@ -20,9 +20,10 @@ class CheckoutOptions {
   Color? textColor;
   Color? payButtonColor;
   Color? cancelButtonColor;
+  Color? primary;
   QRConfiguration? qrConfiguration;
   // Backward compatibility getter for primary color
-  Color? get primary => backgroundColor;
+  //Color? get primary => backgroundColor;
 
   CheckoutOptions(
     this.amount,
@@ -51,6 +52,7 @@ class CheckoutOptions {
       paymentOperation = null;
     }
     backgroundColor ??= const Color(0xff2c2222);
+    primary ??= const Color(0xff327da8);
     cardColor ??= const Color(0xffff4d00);
     textColor ??= const Color(0xffffffff);
     payButtonColor ??= const Color(0xffff4d00);

--- a/lib/widgets/checkout/checkout_options.dart
+++ b/lib/widgets/checkout/checkout_options.dart
@@ -21,6 +21,8 @@ class CheckoutOptions {
   Color? payButtonColor;
   Color? cancelButtonColor;
   QRConfiguration? qrConfiguration;
+  // Backward compatibility getter for primary color
+  Color? get primary => backgroundColor;
 
   CheckoutOptions(
     this.amount,

--- a/lib/widgets/checkout/credit_card_screen.dart
+++ b/lib/widgets/checkout/credit_card_screen.dart
@@ -229,7 +229,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      primary:
+                                      backgroundColor:
                                           widget.checkoutOptions.payButtonColor,
                                     ),
                                     child: Container(
@@ -282,7 +282,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      primary: widget
+                                      backgroundColor: widget
                                           .checkoutOptions.cancelButtonColor,
                                     ),
                                     child: Container(
@@ -850,7 +850,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      primary:
+                                      backgroundColor:
                                           widget.checkoutOptions.payButtonColor,
                                     ),
                                     child: Container(
@@ -911,7 +911,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      primary: widget
+                                      backgroundColor: widget
                                           .checkoutOptions.cancelButtonColor,
                                     ),
                                     child: Container(

--- a/lib/widgets/checkout/credit_card_screen.dart
+++ b/lib/widgets/checkout/credit_card_screen.dart
@@ -81,7 +81,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
         body: Stack(
           children: [
             Container(
-              color: widget.checkoutOptions.backgroundColor,
+              color: widget.checkoutOptions.primary,
               child: SafeArea(
                 child: Column(
                   children: <Widget>[
@@ -142,7 +142,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                     : Icon(
                                         Icons.call_to_action_rounded,
                                         color: widget
-                                            .checkoutOptions.backgroundColor,
+                                            .checkoutOptions.primary,
                                       ),
                               ),
                               expiryDateDecoration: InputDecoration(
@@ -229,7 +229,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      backgroundColor:
+                                      primary:
                                           widget.checkoutOptions.payButtonColor,
                                     ),
                                     child: Container(
@@ -282,7 +282,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      backgroundColor: widget
+                                      primary: widget
                                           .checkoutOptions.cancelButtonColor,
                                     ),
                                     child: Container(
@@ -713,7 +713,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
         body: Stack(
           children: [
             Container(
-              color: widget.checkoutOptions.backgroundColor,
+              color: widget.checkoutOptions.primary,
               child: SafeArea(
                 child: Column(
                   children: <Widget>[
@@ -763,7 +763,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                     : Icon(
                                         Icons.call_to_action_rounded,
                                         color: widget
-                                            .checkoutOptions.backgroundColor,
+                                            .checkoutOptions.primary,
                                       ),
                               ),
                               expiryDateDecoration: InputDecoration(
@@ -850,7 +850,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      backgroundColor:
+                                      primary:
                                           widget.checkoutOptions.payButtonColor,
                                     ),
                                     child: Container(
@@ -911,7 +911,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      backgroundColor: widget
+                                      primary: widget
                                           .checkoutOptions.cancelButtonColor,
                                     ),
                                     child: Container(

--- a/lib/widgets/checkout/credit_card_screen.dart
+++ b/lib/widgets/checkout/credit_card_screen.dart
@@ -229,7 +229,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      primary:
+                                      backgroundColor:
                                           widget.checkoutOptions.payButtonColor,
                                     ),
                                     child: Container(
@@ -282,7 +282,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      primary: widget
+                                      backgroundColor: widget
                                           .checkoutOptions.cancelButtonColor,
                                     ),
                                     child: Container(

--- a/lib/widgets/checkout/credit_card_screen.dart
+++ b/lib/widgets/checkout/credit_card_screen.dart
@@ -850,7 +850,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      primary:
+                                      backgroundColor:
                                           widget.checkoutOptions.payButtonColor,
                                     ),
                                     child: Container(
@@ -911,7 +911,7 @@ class CreditCardScreenState extends State<CreditCardScreen> {
                                         borderRadius:
                                             BorderRadius.circular(8.0),
                                       ),
-                                      primary: widget
+                                      backgroundColor: widget
                                           .checkoutOptions.cancelButtonColor,
                                     ),
                                     child: Container(

--- a/lib/widgets/checkout/credit_card_widget.dart
+++ b/lib/widgets/checkout/credit_card_widget.dart
@@ -232,7 +232,7 @@ class _CreditCardWidgetState extends State<CreditCardWidget>
   ///
   Widget _buildFrontContainer() {
     final TextStyle defaultTextStyle =
-        Theme.of(context).textTheme.headline6!.merge(
+        Theme.of(context).textTheme.headlineSmall!.merge(
               const TextStyle(
                 color: Colors.white,
                 fontFamily: 'halter',
@@ -343,7 +343,7 @@ class _CreditCardWidgetState extends State<CreditCardWidget>
   ///
   Widget _buildBackContainer() {
     final TextStyle defaultTextStyle =
-        Theme.of(context).textTheme.headline6!.merge(
+        Theme.of(context).textTheme.headlineSmall!.merge(
               const TextStyle(
                 color: Colors.black,
                 fontFamily: 'halter',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.13.5
-  intl: ^0.18.1
+  intl: ^0.19.0
   meta: ^1.7.0
   async: ^2.8.2
   html: ^0.15.3


### PR DESCRIPTION
fix: Update for Flutter 3.x compatibility

Bump intl to ^0.19.0 for Flutter 3.x support
Replace deprecated ElevatedButton 'primary' with 'backgroundColor'
Add missing 'primary' property to CheckoutOptions model
This resolves deprecation warnings and ensures compatibility with newer Flutter versions.